### PR TITLE
Add clang-format CI job and format source files

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,14 @@
+Language: Cpp
+BasedOnStyle: Google
+IndentWidth: 2
+ColumnLimit: 80
+AllowShortBlocksOnASingleLine: Always
+AllowShortFunctionsOnASingleLine: Empty
+AllowShortIfStatementsOnASingleLine: false
+AllowShortLoopsOnASingleLine: false
+BinPackArguments: true
+BinPackParameters: true
+BreakBeforeBraces: Attach
+DerivePointerAlignment: false
+PointerAlignment: Left
+SpacesBeforeTrailingComments: 1

--- a/.github/workflows/githubci.yml
+++ b/.github/workflows/githubci.yml
@@ -3,9 +3,26 @@ name: Arduino Library CI
 on: [pull_request, push, repository_dispatch]
 
 jobs:
+  clang-format:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/setup-python@v4
+      with:
+        python-version: '3.x'
+    - uses: actions/checkout@v3
+    - uses: actions/checkout@v3
+      with:
+         repository: adafruit/ci-arduino
+         path: ci
+
+    - name: clang
+      run: python3 ci/run-clang-format.py -e "ci/*" -e "bin/*" -r .
+
   build:
     runs-on: ubuntu-latest
-    
+    needs: clang-format
+
     steps:
     - uses: actions/setup-python@v4
       with:
@@ -21,9 +38,6 @@ jobs:
 
     - name: test platforms
       run: python3 ci/build_platform.py grand_central pico_rp2040
-
-    - name: clang
-      run: python3 ci/run-clang-format.py -e "ci/*" -e "bin/*" -r . 
 
     - name: doxygen
       env:

--- a/src/Adafruit_ImageCapture.cpp
+++ b/src/Adafruit_ImageCapture.cpp
@@ -34,7 +34,7 @@
 
 #include <string.h> // memcpy()
 
-Adafruit_ImageCapture::Adafruit_ImageCapture(iCap_arch *arch, uint16_t *pbuf,
+Adafruit_ImageCapture::Adafruit_ImageCapture(iCap_arch* arch, uint16_t* pbuf,
                                              uint32_t pbufsize)
     : arch(arch) {
   if (pbuf && pbufsize) {     // Pixel buffer and size passed in:
@@ -79,25 +79,25 @@ iCap_status Adafruit_ImageCapture::bufferConfig(uint16_t width, uint16_t height,
 
   Serial.printf("%d %d %d %d\n", width, height, allo, new_buffer_size);
   switch (allo) {
-  case ICAP_REALLOC_NONE:
-    // Don't reallocate, keep existing buffer...test if it fits though...
-    if (new_buffer_size > pixbuf_size) { // New size won't fit
-      // No realloc. Keep current camera settings, return error.
-      return ICAP_STATUS_ERR_MALLOC;
-    }
-    break;
-  case ICAP_REALLOC_CHANGE:
-    // Realloc on any size change, up or down
-    ra = (new_buffer_size != pixbuf_size);
-    break;
-  case ICAP_REALLOC_LARGER:
-    // Realloc on size increase, keep existing buffer if size decrease
-    ra = (new_buffer_size > pixbuf_size);
-    break;
+    case ICAP_REALLOC_NONE:
+      // Don't reallocate, keep existing buffer...test if it fits though...
+      if (new_buffer_size > pixbuf_size) { // New size won't fit
+        // No realloc. Keep current camera settings, return error.
+        return ICAP_STATUS_ERR_MALLOC;
+      }
+      break;
+    case ICAP_REALLOC_CHANGE:
+      // Realloc on any size change, up or down
+      ra = (new_buffer_size != pixbuf_size);
+      break;
+    case ICAP_REALLOC_LARGER:
+      // Realloc on size increase, keep existing buffer if size decrease
+      ra = (new_buffer_size > pixbuf_size);
+      break;
   }
 
   if (ra) { // Reallocate?
-    pixbuf[0] = (uint16_t *)realloc(pixbuf[0], new_buffer_size);
+    pixbuf[0] = (uint16_t*)realloc(pixbuf[0], new_buffer_size);
     if (pixbuf[0] == NULL) { // ALLOC FAIL
       _width = _height = pixbuf_size = 0;
       pixbuf[1] = pixbuf[2] = NULL;
@@ -129,7 +129,7 @@ void Adafruit_ImageCapture::image_negative() {
   // on a 32-bit-safe boundary. This is one of those operations that
   // can probably be implemented through the camera's gamma curve
   // settings, and if so this function will go away.
-  uint32_t *p32 = (uint32_t *)pixbuf[0];
+  uint32_t* p32 = (uint32_t*)pixbuf[0];
   uint32_t i, num_pairs = _width * _height / 2;
   for (i = 0; i < num_pairs; i++) {
     p32[i] ^= 0xFFFFFFFF;
@@ -141,7 +141,7 @@ void Adafruit_ImageCapture::image_negative() {
 // range for the colorspace.
 void Adafruit_ImageCapture::image_threshold(uint8_t threshold) {
   uint32_t i, num_pixels = _width * _height;
-  uint16_t *pixels = pixbuf[0];
+  uint16_t* pixels = pixbuf[0];
   if (colorspace == ICAP_COLOR_RGB565) {
     // Testing RGB thresholds "in place" in the packed RGB565 value
     // avoids some bit-shifting on every pixel (just bit masking).
@@ -164,7 +164,7 @@ void Adafruit_ImageCapture::image_threshold(uint8_t threshold) {
       pixels[i] = __builtin_bswap16(rgb565out); //   Back to cam-native endian
     }
   } else {                                    // YUV...
-    uint8_t *p8 = (uint8_t *)pixels;          // Separate Y's, U's, V's
+    uint8_t* p8 = (uint8_t*)pixels;           // Separate Y's, U's, V's
     num_pixels *= 2;                          // Actually num bytes now
     for (i = 0; i < num_pixels; i++) {        // For each byte...
       p8[i] = (p8[i] >= threshold) ? 255 : 0; //   Threshold to 0 or 255
@@ -176,7 +176,7 @@ void Adafruit_ImageCapture::image_threshold(uint8_t threshold) {
 
 // Reduce color fidelity to a specified number of steps or levels.
 void Adafruit_ImageCapture::image_posterize(uint8_t levels) {
-  uint16_t *pixels = pixbuf[0];
+  uint16_t* pixels = pixbuf[0];
   uint32_t i, num_pixels = _width * _height;
 
   if (levels < 1) {
@@ -218,7 +218,7 @@ void Adafruit_ImageCapture::image_posterize(uint8_t levels) {
       for (i = 0; i < 256; i++) {
         table[i] = (((i * levels + lm1d2) / 256) * 255 + lm1d2) / lm1;
       }
-      uint8_t *p8 = (uint8_t *)pixels;   // Separate Ys, Us, Vs
+      uint8_t* p8 = (uint8_t*)pixels;    // Separate Ys, Us, Vs
       num_pixels *= 2;                   // Actually num bytes now
       for (i = 0; i < num_pixels; i++) { // For each byte...
         p8[i] = table[p8[i]];            //   Remap through lookup table
@@ -247,7 +247,7 @@ void Adafruit_ImageCapture::image_mosaic(uint8_t tile_width,
   uint16_t tile_x, tile_y;
   uint16_t x1, x2, y1, y2, xx, yy; // Tile bounds, counters
   uint32_t pixels_in_tile;
-  uint16_t *pixels = pixbuf[0];
+  uint16_t* pixels = pixbuf[0];
 
   if (colorspace == ICAP_COLOR_RGB565) {
     uint16_t rgb;
@@ -400,10 +400,10 @@ void Adafruit_ImageCapture::image_mosaic(uint8_t tile_width,
 // median to operate on all source image pixels, no black border or other
 // uglies. Pixels within each channel are not sequential in memory, but
 // increment by 3's -- corresponding to the prior, current and next rows.
-static void iCap_filter_row_prep(uint16_t *src, uint8_t *r_dst, uint16_t width,
+static void iCap_filter_row_prep(uint16_t* src, uint8_t* r_dst, uint16_t width,
                                  uint32_t channel_bytes) {
-  uint8_t *g_dst = &r_dst[channel_bytes];
-  uint8_t *b_dst = &g_dst[channel_bytes];
+  uint8_t* g_dst = &r_dst[channel_bytes];
+  uint8_t* b_dst = &g_dst[channel_bytes];
 
   uint16_t x, rgb, offset = 3;
   for (x = 0; x < width; x++) {        // For each pixel in row...
@@ -423,12 +423,12 @@ static void iCap_filter_row_prep(uint16_t *src, uint8_t *r_dst, uint16_t width,
 }
 
 // Copy a single row in the 3x3 filter weird increment-by-3 pixel format.
-static void iCap_filter_row_copy(uint8_t *r_src, uint8_t *r_dst, uint16_t width,
+static void iCap_filter_row_copy(uint8_t* r_src, uint8_t* r_dst, uint16_t width,
                                  uint32_t channel_bytes) {
-  uint8_t *g_src = &r_src[channel_bytes];
-  uint8_t *b_src = &g_src[channel_bytes];
-  uint8_t *g_dst = &r_dst[channel_bytes];
-  uint8_t *b_dst = &g_dst[channel_bytes];
+  uint8_t* g_src = &r_src[channel_bytes];
+  uint8_t* b_src = &g_src[channel_bytes];
+  uint8_t* g_dst = &r_dst[channel_bytes];
+  uint8_t* b_dst = &g_dst[channel_bytes];
   uint16_t x, offset;
 
   for (x = offset = 0; x < width; x++, offset += 3) {
@@ -439,8 +439,7 @@ static void iCap_filter_row_copy(uint8_t *r_src, uint8_t *r_dst, uint16_t width,
 }
 
 // Determine median value of 9-element list
-static inline uint8_t iCap_med9(uint8_t *list) {
-
+static inline uint8_t iCap_med9(uint8_t* list) {
   // Find median value in a list of 9 (index 0 to 8). Ostensibly,
   // conceptually, this would involve sorting the list (ascending or
   // descending, doesn't matter) and returning the value at index 4.
@@ -517,14 +516,14 @@ static inline uint8_t iCap_med9(uint8_t *list) {
 // ((width + 2) * 3 + height - 1) * 3 bytes, or about 3.6K for a 320x240
 // RGB image. YUV is not currently supported.
 void Adafruit_ImageCapture::image_median() {
-  uint16_t *pixels = pixbuf[0];
+  uint16_t* pixels = pixbuf[0];
   if (colorspace == ICAP_COLOR_RGB565) {
-    uint8_t *buf;
+    uint8_t* buf;
     uint32_t buf_bytes_per_channel = (_width + 2) * 3 + _height - 1;
-    if ((buf = (uint8_t *)malloc(buf_bytes_per_channel * 3))) {
-      uint8_t *rptr = buf;                          // -> red buffer
-      uint8_t *gptr = &rptr[buf_bytes_per_channel]; // -> green buffer
-      uint8_t *bptr = &gptr[buf_bytes_per_channel]; // -> blue buffer
+    if ((buf = (uint8_t*)malloc(buf_bytes_per_channel * 3))) {
+      uint8_t* rptr = buf;                          // -> red buffer
+      uint8_t* gptr = &rptr[buf_bytes_per_channel]; // -> green buffer
+      uint8_t* bptr = &gptr[buf_bytes_per_channel]; // -> blue buffer
 
       // For each of the three channel pointers (rptr, gptr, bptr),
       // ptr[0] is the first pixel of the row ABOVE the current one,
@@ -541,7 +540,7 @@ void Adafruit_ImageCapture::image_median() {
       // (Because edge pixels are repeated so we can 3x3 filter full image)
       iCap_filter_row_copy(&rptr[1], rptr, _width + 2, buf_bytes_per_channel);
 
-      uint16_t *ptr = pixels; // Dest pointer, back into source image
+      uint16_t* ptr = pixels; // Dest pointer, back into source image
       uint16_t x, y, offset, rgb;
       uint8_t r_med, g_med, b_med;
       for (y = 0; y < _height; y++) { // For each row of image...
@@ -586,7 +585,7 @@ void Adafruit_ImageCapture::image_median() {
 // pixel and the four pixels above, below, left and right, sets result 'on'
 // if any of those 4 exceeds a given threshold. Note to future self: might
 // instead evaluate sum-of-four rather than any-of-four.
-static inline bool iCap_edge9(uint8_t *list, uint8_t sensitivity) {
+static inline bool iCap_edge9(uint8_t* list, uint8_t sensitivity) {
   int8_t center = (int16_t)list[4];                 // Must be signed!
   return ((abs(center - list[1]) >= sensitivity) || // left
           (abs(center - list[3]) >= sensitivity) || // up
@@ -598,15 +597,15 @@ static inline bool iCap_edge9(uint8_t *list, uint8_t sensitivity) {
 // ((width + 2) * 3 + height - 1) * 3 bytes, or about 3.6K for a
 // 320x240 RGB image. YUV is not currently supported.
 void Adafruit_ImageCapture::image_edges(uint8_t sensitivity) {
-  uint16_t *pixels = pixbuf[0];
+  uint16_t* pixels = pixbuf[0];
 
   if (colorspace == ICAP_COLOR_RGB565) {
-    uint8_t *buf;
+    uint8_t* buf;
     uint32_t buf_bytes_per_channel = (_width + 2) * 3 + _height - 1;
-    if ((buf = (uint8_t *)malloc(buf_bytes_per_channel * 3))) {
-      uint8_t *rptr = buf;                          // -> red buffer
-      uint8_t *gptr = &rptr[buf_bytes_per_channel]; // -> green buffer
-      uint8_t *bptr = &gptr[buf_bytes_per_channel]; // -> blue buffer
+    if ((buf = (uint8_t*)malloc(buf_bytes_per_channel * 3))) {
+      uint8_t* rptr = buf;                          // -> red buffer
+      uint8_t* gptr = &rptr[buf_bytes_per_channel]; // -> green buffer
+      uint8_t* bptr = &gptr[buf_bytes_per_channel]; // -> blue buffer
 
       // For each of the three channel pointers (rptr, gptr, bptr),
       // ptr[0] is the first pixel of the row ABOVE the current one,
@@ -625,7 +624,7 @@ void Adafruit_ImageCapture::image_edges(uint8_t sensitivity) {
 
       uint8_t s2 = sensitivity * 2; // Because green has extra bit
 
-      uint16_t *ptr = pixels; // Dest pointer, back into source image
+      uint16_t* ptr = pixels; // Dest pointer, back into source image
       uint16_t x, y, offset, rgb;
       for (y = 0; y < _height; y++) { // For each row of image...
         // Set up 'below' row buffer...
@@ -661,7 +660,7 @@ void Adafruit_ImageCapture::image_edges(uint8_t sensitivity) {
 // Reformat YUV gray component to RGB565 for TFT preview.
 // Big-endian in and out.
 void Adafruit_ImageCapture::Y2RGB565() {
-  uint16_t *pixels = pixbuf[0];
+  uint16_t* pixels = pixbuf[0];
   uint32_t len = _width * _height;
   while (len--) {
     uint8_t y = *pixels & 0xFF; // Y (brightness) component of YUV

--- a/src/Adafruit_ImageCapture.h
+++ b/src/Adafruit_ImageCapture.h
@@ -63,7 +63,7 @@ typedef enum {
     @brief  Class encapsulating common image sensor functionality.
 */
 class Adafruit_ImageCapture {
-public:
+ public:
   /*!
     @brief  Constructor for Adafruit_ImageCapture class. This constructor
             is never invoked directly by user code. Instead, a subclass is
@@ -81,7 +81,7 @@ public:
                       resolution is selected.
     @param  pbufsize  Size of passed-in buffer (or 0 if NULL).
   */
-  Adafruit_ImageCapture(iCap_arch *arch, uint16_t *pbuf, uint32_t pbufsize);
+  Adafruit_ImageCapture(iCap_arch* arch, uint16_t* pbuf, uint32_t pbufsize);
   ~Adafruit_ImageCapture(); // Destructor
 
   /*!
@@ -124,19 +124,25 @@ public:
     @brief   Get image width of camera's current resolution setting.
     @return  Width in pixels.
   */
-  uint16_t width(void) { return _width; }
+  uint16_t width(void) {
+    return _width;
+  }
 
   /*!
     @brief   Get image height of camera's current resolution setting.
     @return  Height in pixels.
   */
-  uint16_t height(void) { return _height; }
+  uint16_t height(void) {
+    return _height;
+  }
 
   /*!
     @brief   Get address of image buffer being used by camera.
     @return  uint16_t pointer to last-captured image data.
   */
-  uint16_t *getBuffer(void) { return pixbuf[0]; }
+  uint16_t* getBuffer(void) {
+    return pixbuf[0];
+  }
 
   /*!
     @brief  Produces a negative image. This is a postprocessing effect,
@@ -211,15 +217,15 @@ public:
   */
   void Y2RGB565(void);
 
-protected:
-  uint16_t *pixbuf[3];        ///< Frame pointers (up to 3) into pixel buffer
+ protected:
+  uint16_t* pixbuf[3];        ///< Frame pointers (up to 3) into pixel buffer
   uint32_t pixbuf_size = 0;   ///< Full size of pixbuf, in bytes
   uint8_t bufmode;            ///< 1-3 = single-, double-, triple-buffered
   bool pixbuf_allocable;      ///< Internally allocated vs static buffer
   uint16_t _width = 0;        ///< Current settings width in pixels
   uint16_t _height = 0;       ///< Current settings height in pixels
   iCap_colorspace colorspace; ///< Current settings colorspace
-  iCap_arch *arch = NULL;     ///< Device-specific data, if needed
+  iCap_arch* arch = NULL;     ///< Device-specific data, if needed
 
   // No longer used
   //  iCap_status setSize(uint16_t width, uint16_t height, uint8_t nbuf=1,

--- a/src/Adafruit_iCap_I2C_host.cpp
+++ b/src/Adafruit_iCap_I2C_host.cpp
@@ -14,9 +14,10 @@
  */
 
 #include "Adafruit_iCap_I2C_host.h"
+
 #include <Arduino.h>
 
-Adafruit_iCap_peripheral::Adafruit_iCap_peripheral(uint8_t addr, TwoWire *w,
+Adafruit_iCap_peripheral::Adafruit_iCap_peripheral(uint8_t addr, TwoWire* w,
                                                    uint32_t s)
     : i2cAddress(addr), wire(w), i2cSpeed(s) {}
 

--- a/src/Adafruit_iCap_I2C_host.h
+++ b/src/Adafruit_iCap_I2C_host.h
@@ -15,17 +15,18 @@
 
 #pragma once
 
-#include "Adafruit_iCap_I2C.h"
 #include <Wire.h>
 #include <stdint.h>
+
+#include "Adafruit_iCap_I2C.h"
 #if !defined(BUFFER_LENGTH)
 #define BUFFER_LENGTH 256
 #endif
 
 class Adafruit_iCap_peripheral {
-public:
+ public:
   Adafruit_iCap_peripheral(uint8_t addr = ICAP_DEFAULT_ADDRESS,
-                           TwoWire *w = &Wire, uint32_t s = 400000UL);
+                           TwoWire* w = &Wire, uint32_t s = 400000UL);
   ~Adafruit_iCap_peripheral(); // Destructor
 
   void begin(void);
@@ -33,7 +34,7 @@ public:
              uint32_t timeout_ms = 3000);
   int getReturnValue();
   iCap_state getState();
-  uint8_t *getData(int len);
+  uint8_t* getData(int len);
   int config(uint8_t size, uint8_t space, float fps = 30.0,
              uint32_t timeout_ms = 3000);
   int readRegister(uint8_t reg);
@@ -45,20 +46,26 @@ public:
     @brief   Get image width of camera's current resolution setting.
     @return  Width in pixels.
   */
-  uint16_t width(void) { return _width; }
+  uint16_t width(void) {
+    return _width;
+  }
 
   /*!
     @brief   Get image height of camera's current resolution setting.
     @return  Height in pixels.
   */
-  uint16_t height(void) { return _height; }
+  uint16_t height(void) {
+    return _height;
+  }
 
   /*!
     @brief   Get maximum I2C transfer size that was negotiated between
              host and peripheral during begin().
     @return  Maximum single transfer size, in bytes.
   */
-  uint32_t maxTransferSize(void) { return i2cMaxLen; }
+  uint32_t maxTransferSize(void) {
+    return i2cMaxLen;
+  }
 
   /*!
     @brief   Get address of I2C receive buffer. When capturing image,
@@ -66,7 +73,9 @@ public:
              to display or other code.
     @return  Pointer to receive buffer (BUFFER_LENGTH bytes).
   */
-  uint8_t *getBuffer(void) { return i2cBuf; };
+  uint8_t* getBuffer(void) {
+    return i2cBuf;
+  };
 
   /*!
     @brief   Read data from I2C peripheral camera, up to a maximum length
@@ -83,8 +92,8 @@ public:
   // Write data to I2C peripheral camera from library's transfer buffer.
   int i2cWrite(int len);
 
-protected:
-  TwoWire *wire;                 //< Pointer to I2C periph (e.g. &Wire)
+ protected:
+  TwoWire* wire;                 //< Pointer to I2C periph (e.g. &Wire)
   uint32_t i2cSpeed;             //< I2C data rate, bps (e.g. 100000)
   uint8_t i2cAddress;            //< I2C peripheral address
   uint8_t i2cBuf[BUFFER_LENGTH]; //< TX/RX buffer, size from Wire lib

--- a/src/Adafruit_iCap_OV2640.cpp
+++ b/src/Adafruit_iCap_OV2640.cpp
@@ -3,18 +3,19 @@
 
 #if defined(ICAP_FULL_SUPPORT)
 
-Adafruit_iCap_OV2640::Adafruit_iCap_OV2640(OV2640_pins &pins, iCap_arch *arch,
-                                           TwoWire &twi, uint16_t *pbuf,
+Adafruit_iCap_OV2640::Adafruit_iCap_OV2640(OV2640_pins& pins, iCap_arch* arch,
+                                           TwoWire& twi, uint16_t* pbuf,
                                            uint32_t pbufsize, uint8_t addr,
                                            uint32_t speed, uint32_t delay_us)
-    : Adafruit_iCap_parallel((iCap_parallel_pins *)&pins, arch, pbuf, pbufsize,
-                             (TwoWire *)&twi, addr, speed, delay_us) {}
+    : Adafruit_iCap_parallel((iCap_parallel_pins*)&pins, arch, pbuf, pbufsize,
+                             (TwoWire*)&twi, addr, speed, delay_us) {}
 
 Adafruit_iCap_OV2640::~Adafruit_iCap_OV2640() {}
 
 // CAMERA STARTUP ----------------------------------------------------------
 
-static const iCap_parallel_config OV2640_init[] = {
+static const iCap_parallel_config OV2640_init[] =
+    {
 #if 0
 // Ideas from esp32-camera
 // not working yet (scrambled image)
@@ -176,7 +177,7 @@ static const iCap_parallel_config OV2640_init[] = {
         {OV2640_REG0_RESET, 0}, // Go
         {OV2640_REG0_R_BYPASS, OV2640_R_BYPASS_DSP_ENABLE}},
 #else
-// Ideas from rp2040_ov2640-main repo
+        // Ideas from rp2040_ov2640-main repo
         // OV2640 camera initialization after reset
         // WIP STUFF, don't take this seriously yet
         {OV2640_REG_RA_DLMT, OV2640_RA_DLMT_DSP},    // DSP bank select 0
@@ -191,17 +192,18 @@ static const iCap_parallel_config OV2640_init[] = {
         {OV2640_REG1_COM8, 0xC0 | OV2640_COM8_BANDING | OV2640_COM8_AGC_AUTO |
                                OV2640_COM8_EXP_AUTO},
         {OV2640_REG1_COM9, OV2640_COM9_AGC_GAIN_8X | 0x08},
-        {0x2C, 0x0c},            // Reserved
-        {0x33, 0x78},            // Reserved
-        {0x3A, 0x33},            // Reserved
-        {0x3B, 0xfB},            // Reserved
-        {0x3E, 0x00},            // Reserved
-        {0x43, 0x11},            // Reserved
-        {0x16, 0x10},            // Reserved
-        {0x4A, 0x81},            // Reserved
-        {0x21, 0x99},            // Reserved
-//        {OV2640_REG1_AEW, 0x40}, // High range for AEC/AGC
-//        {OV2640_REG1_AEB, 0x38}, // Low range for AEC/AGC
+        {0x2C, 0x0c}, // Reserved
+        {0x33, 0x78}, // Reserved
+        {0x3A, 0x33}, // Reserved
+        {0x3B, 0xfB}, // Reserved
+        {0x3E, 0x00}, // Reserved
+        {0x43, 0x11}, // Reserved
+        {0x16, 0x10}, // Reserved
+        {0x4A, 0x81}, // Reserved
+        {0x21,
+         0x99}, // Reserved
+                //        {OV2640_REG1_AEW, 0x40}, // High range for AEC/AGC
+                //        {OV2640_REG1_AEB, 0x38}, // Low range for AEC/AGC
         {OV2640_REG1_AEW, 0xFF}, // High range for AEC/AGC
         {OV2640_REG1_AEB, 0x00}, // Low range for AEC/AGC
         {OV2640_REG1_VV, 0x82},  // Fast mode thresholds
@@ -375,11 +377,11 @@ static const iCap_parallel_config OV2640_init[] = {
         {OV2640_REG0_ZMHH, 0x00},                       // OUTW/H high bits
         {OV2640_REG0_R_DVP_SP, 0x04},                   // Manual DVP PCLK
         {0x7F, 0x00},                                   // Reserved
-//        {OV2640_REG0_IMAGE_MODE, 0x00},                 // YUV MSB first
-        {0xE5, 0x1F},                                   // Reserved
-        {0xE1, 0x67},                                   // Reserved
-        {OV2640_REG0_RESET, 0x00},                      // Reset nothing?
-        {0xDD, 0x7F},                                   // Reserved
+                      //        {OV2640_REG0_IMAGE_MODE, 0x00}, // YUV MSB first
+        {0xE5, 0x1F},              // Reserved
+        {0xE1, 0x67},              // Reserved
+        {OV2640_REG0_RESET, 0x00}, // Reset nothing?
+        {0xDD, 0x7F},              // Reserved
         {OV2640_REG0_R_BYPASS, OV2640_R_BYPASS_DSP_ENABLE},
         {OV2640_REG_RA_DLMT, OV2640_RA_DLMT_DSP}, // DSP bank select 0
         {OV2640_REG0_RESET, OV2640_RESET_DVP},
@@ -429,25 +431,25 @@ static const iCap_parallel_config OV2640_init[] = {
         {OV2640_REG0_RESET, 0x00}},   // Go
 #endif
     OV2640_qqvga[] =
-        {// Configure OV2640 for QQVGA output
-         {OV2640_REG_RA_DLMT, OV2640_RA_DLMT_DSP}, // DSP bank select 0
-         {OV2640_REG0_RESET, OV2640_RESET_DVP},
-         {OV2640_REG0_HSIZE8, 0x64}, // HSIZE high bits
-         {OV2640_REG0_VSIZE8, 0x4B}, // VSIZE high bits
-         {OV2640_REG0_CTRL2, OV2640_CTRL2_DCW | OV2640_CTRL2_SDE |
-                                 OV2640_CTRL2_UV_AVG | OV2640_CTRL2_CMX},
-         {OV2640_REG0_CTRLI, OV2640_CTRLI_LP_DP | 0x12},
-         {OV2640_REG0_HSIZE, 0xC8},    // H_SIZE low bits
-         {OV2640_REG0_VSIZE, 0x96},    // V_SIZE low bits
-         {OV2640_REG0_XOFFL, 0x00},    // OFFSET_X low bits
-         {OV2640_REG0_YOFFL, 0x00},    // OFFSET_Y low bits
-         {OV2640_REG0_VHYX, 0x00},     // V/H/Y/X high bits
-         {OV2640_REG0_TEST, 0x00},     // ?
-         {OV2640_REG0_ZMOW, 0x28},     // OUTW low bits
-         {OV2640_REG0_ZMOH, 0x1E},     // OUTH low bits
-         {OV2640_REG0_ZMHH, 0x00},     // OUTW/H high bits
-         {OV2640_REG0_R_DVP_SP, 0x08}, // Manual DVP PCLK setting
-         {OV2640_REG0_RESET, 0x00}},   // Go
+        { // Configure OV2640 for QQVGA output
+            {OV2640_REG_RA_DLMT, OV2640_RA_DLMT_DSP}, // DSP bank select 0
+            {OV2640_REG0_RESET, OV2640_RESET_DVP},
+            {OV2640_REG0_HSIZE8, 0x64}, // HSIZE high bits
+            {OV2640_REG0_VSIZE8, 0x4B}, // VSIZE high bits
+            {OV2640_REG0_CTRL2, OV2640_CTRL2_DCW | OV2640_CTRL2_SDE |
+                                    OV2640_CTRL2_UV_AVG | OV2640_CTRL2_CMX},
+            {OV2640_REG0_CTRLI, OV2640_CTRLI_LP_DP | 0x12},
+            {OV2640_REG0_HSIZE, 0xC8},    // H_SIZE low bits
+            {OV2640_REG0_VSIZE, 0x96},    // V_SIZE low bits
+            {OV2640_REG0_XOFFL, 0x00},    // OFFSET_X low bits
+            {OV2640_REG0_YOFFL, 0x00},    // OFFSET_Y low bits
+            {OV2640_REG0_VHYX, 0x00},     // V/H/Y/X high bits
+            {OV2640_REG0_TEST, 0x00},     // ?
+            {OV2640_REG0_ZMOW, 0x28},     // OUTW low bits
+            {OV2640_REG0_ZMOH, 0x1E},     // OUTH low bits
+            {OV2640_REG0_ZMHH, 0x00},     // OUTW/H high bits
+            {OV2640_REG0_R_DVP_SP, 0x08}, // Manual DVP PCLK setting
+            {OV2640_REG0_RESET, 0x00}},   // Go
     OV2640_rgb[] = {{OV2640_REG_RA_DLMT,
                      OV2640_RA_DLMT_DSP}, // DSP bank select 0
                     {OV2640_REG0_RESET, OV2640_RESET_DVP},

--- a/src/Adafruit_iCap_OV2640.h
+++ b/src/Adafruit_iCap_OV2640.h
@@ -17,7 +17,7 @@ typedef iCap_parallel_pins OV2640_pins;
     @brief  Class encapsulating OmniVision OV2640 functionality.
 */
 class Adafruit_iCap_OV2640 : public Adafruit_iCap_parallel {
-public:
+ public:
   /*!
     @brief  Constructor for OV2640 camera class.
     @param  pins      OV2640_pins structure, describing physical connection
@@ -39,8 +39,8 @@ public:
     @param  speed     I2C communication speed to camera.
     @param  delay_us  Delay in microseconds between register writes.
   */
-  Adafruit_iCap_OV2640(iCap_parallel_pins &pins, iCap_arch *arch = NULL,
-                       TwoWire &twi = Wire, uint16_t *pbuf = NULL,
+  Adafruit_iCap_OV2640(iCap_parallel_pins& pins, iCap_arch* arch = NULL,
+                       TwoWire& twi = Wire, uint16_t* pbuf = NULL,
                        uint32_t pbufsize = 0, uint8_t addr = OV2640_ADDR,
                        uint32_t speed = 100000, uint32_t delay_us = 1000);
   ~Adafruit_iCap_OV2640(); // Destructor

--- a/src/Adafruit_iCap_OV7670.cpp
+++ b/src/Adafruit_iCap_OV7670.cpp
@@ -3,12 +3,12 @@
 
 #if defined(ICAP_FULL_SUPPORT)
 
-Adafruit_iCap_OV7670::Adafruit_iCap_OV7670(OV7670_pins &pins, iCap_arch *arch,
-                                           TwoWire &twi, uint16_t *pbuf,
+Adafruit_iCap_OV7670::Adafruit_iCap_OV7670(OV7670_pins& pins, iCap_arch* arch,
+                                           TwoWire& twi, uint16_t* pbuf,
                                            uint32_t pbufsize, uint8_t addr,
                                            uint32_t speed, uint32_t delay_us)
-    : Adafruit_iCap_parallel((iCap_parallel_pins *)&pins, arch, pbuf, pbufsize,
-                             (TwoWire *)&twi, addr, speed, delay_us) {}
+    : Adafruit_iCap_parallel((iCap_parallel_pins*)&pins, arch, pbuf, pbufsize,
+                             (TwoWire*)&twi, addr, speed, delay_us) {}
 
 Adafruit_iCap_OV7670::~Adafruit_iCap_OV7670() {}
 
@@ -243,7 +243,6 @@ void Adafruit_iCap_OV7670::setColorspace(iCap_colorspace space) {
 // evaluated without reconfiguring the camera, or without it even started.
 
 float Adafruit_iCap_OV7670::setFPS(float fps) {
-
   // Pixel clock (PCLK), which determines overall frame rate, is a
   // function of XCLK input frequency (OV7670_XCLK_HZ), a PLL multiplier
   // and then an integer division factor (1-32). These are the available

--- a/src/Adafruit_iCap_OV7670.h
+++ b/src/Adafruit_iCap_OV7670.h
@@ -49,7 +49,7 @@ typedef iCap_parallel_pins OV7670_pins;
     @brief  Class encapsulating OmniVision OV7670 functionality.
 */
 class Adafruit_iCap_OV7670 : public Adafruit_iCap_parallel {
-public:
+ public:
   /*!
     @brief  Constructor for OV7670 camera class.
     @param  pins      OV7670_pins structure, describing physical connection
@@ -71,8 +71,8 @@ public:
     @param  speed     I2C communication speed to camera.
     @param  delay_us  Delay in microseconds between register writes.
   */
-  Adafruit_iCap_OV7670(iCap_parallel_pins &pins, iCap_arch *arch = NULL,
-                       TwoWire &twi = Wire, uint16_t *pbuf = NULL,
+  Adafruit_iCap_OV7670(iCap_parallel_pins& pins, iCap_arch* arch = NULL,
+                       TwoWire& twi = Wire, uint16_t* pbuf = NULL,
                        uint32_t pbufsize = 0, uint8_t addr = OV7670_ADDR,
                        uint32_t speed = 100000, uint32_t delay_us = 1000);
   ~Adafruit_iCap_OV7670();
@@ -234,7 +234,7 @@ public:
   */
   void test_pattern(OV7670_pattern pattern);
 
-private:
+ private:
 };
 
 #endif // end ICAP_FULL_SUPPORT

--- a/src/Adafruit_iCap_parallel.cpp
+++ b/src/Adafruit_iCap_parallel.cpp
@@ -4,14 +4,17 @@
 
 #include <Arduino.h>
 
-Adafruit_iCap_parallel::Adafruit_iCap_parallel(iCap_parallel_pins *pins_ptr,
-                                               iCap_arch *arch, uint16_t *pbuf,
+Adafruit_iCap_parallel::Adafruit_iCap_parallel(iCap_parallel_pins* pins_ptr,
+                                               iCap_arch* arch, uint16_t* pbuf,
                                                uint32_t pbufsize,
-                                               TwoWire *twi_ptr, uint8_t addr,
+                                               TwoWire* twi_ptr, uint8_t addr,
                                                uint32_t speed,
                                                uint32_t delay_us)
-    : i2c_address(addr & 0x7F), i2c_speed(speed), i2c_delay_us(delay_us),
-      wire(twi_ptr), Adafruit_ImageCapture(arch, pbuf, pbufsize) {
+    : i2c_address(addr & 0x7F),
+      i2c_speed(speed),
+      i2c_delay_us(delay_us),
+      wire(twi_ptr),
+      Adafruit_ImageCapture(arch, pbuf, pbufsize) {
   memcpy(&pins, pins_ptr, sizeof pins); // Save pins struct in object
 }
 
@@ -71,7 +74,7 @@ void Adafruit_iCap_parallel::writeRegister(uint8_t reg, uint8_t value) {
   wire->endTransmission();
 }
 
-void Adafruit_iCap_parallel::writeList(const iCap_parallel_config *cfg,
+void Adafruit_iCap_parallel::writeList(const iCap_parallel_config* cfg,
                                        uint16_t len) {
   for (int i = 0; i < len; i++) {
     writeRegister(cfg[i].reg, cfg[i].value);

--- a/src/Adafruit_iCap_parallel.h
+++ b/src/Adafruit_iCap_parallel.h
@@ -32,7 +32,7 @@ typedef struct {
             any later sensors instead use SPI, etc. for the pixel interface.)
 */
 class Adafruit_iCap_parallel : public Adafruit_ImageCapture {
-public:
+ public:
   /*!
     @brief  Constructor for Adafruit_iCap_parallel class. This constructor
             is never invoked directly by user code. Instead, a subclass is
@@ -59,8 +59,8 @@ public:
                       MCUs and/or cameras may cause lockup without some
                       delay).
   */
-  Adafruit_iCap_parallel(iCap_parallel_pins *pins_ptr, iCap_arch *arch,
-                         uint16_t *pbuf, uint32_t pbufsize, TwoWire *twi_ptr,
+  Adafruit_iCap_parallel(iCap_parallel_pins* pins_ptr, iCap_arch* arch,
+                         uint16_t* pbuf, uint32_t pbufsize, TwoWire* twi_ptr,
                          uint8_t addr, uint32_t speed, uint32_t delay_us);
   ~Adafruit_iCap_parallel(); // Destructor
 
@@ -118,7 +118,7 @@ public:
     @param  cfg  Array (pointer-to) of settings to write.
     @param  len  Length of array.
   */
-  void writeList(const iCap_parallel_config *cfg, uint16_t len);
+  void writeList(const iCap_parallel_config* cfg, uint16_t len);
 
   /*!
     @brief  Pause DMA background capture (if supported by architecture)
@@ -135,7 +135,7 @@ public:
   */
   void resume(void);
 
-protected:
+ protected:
   /*!
     @brief   Starter function for the XCLK output signal.
     @param   freq  Desired XCLK frequency in Hz. Typically the ICAP_XCLK_HZ
@@ -156,9 +156,9 @@ protected:
     @param   dest        Destination for data received from camera.
     @param   num_pixels  Number of pixels in image.
   */
-  void dma_change(uint16_t *dest, uint32_t num_pixels);
+  void dma_change(uint16_t* dest, uint32_t num_pixels);
 
-  TwoWire *wire;           ///< Associated I2C instance
+  TwoWire* wire;           ///< Associated I2C instance
   iCap_parallel_pins pins; ///< Pin structure (copied in constructor)
   uint32_t i2c_speed;      ///< I2C bus speed
   uint32_t i2c_delay_us;   ///< Delay in microseconds between I2C writes

--- a/src/arch/rp2040.cpp
+++ b/src/arch/rp2040.cpp
@@ -1,10 +1,11 @@
 #if defined(ARDUINO_ARCH_RP2040)
+#include <Adafruit_iCap_parallel.h>
+
 #include "../../hardware_dma/include/hardware/dma.h"
 #include "hardware/gpio.h"
 #include "hardware/irq.h"
 #include "hardware/pio.h"
 #include "hardware/pwm.h"
-#include <Adafruit_iCap_parallel.h>
 
 // PIO code in this table is modified at runtime so that PCLK is
 // configurable (rather than fixed GP## or PIN offset). Data pins
@@ -28,8 +29,8 @@ static struct pio_program iCap_pio_program = {
 // needs to access to object- and arch-specific data like the camera buffer
 // and DMA settings, pointers are kept (initialized in the begin() function).
 // This does mean that only a single OV7670 can be active.
-static Adafruit_ImageCapture *capptr = NULL; // Camera buffer, size, etc.
-static iCap_arch *archptr = NULL;            // DMA settings
+static Adafruit_ImageCapture* capptr = NULL; // Camera buffer, size, etc.
+static iCap_arch* archptr = NULL;            // DMA settings
 static volatile bool frameReady = false;     // true at end-of-frame
 static volatile bool suspended = true;       // Initially stopped
 
@@ -74,7 +75,7 @@ static void iCap_dma_finish_irq() {
   frameReady = true;
   // Channel MUST be reconfigured each time (to reset the dest address).
   dma_channel_set_write_addr(archptr->dma_channel,
-                             (uint8_t *)(capptr->getBuffer()), false);
+                             (uint8_t*)(capptr->getBuffer()), false);
   dma_hw->ints0 = 1u << archptr->dma_channel; // Clear IRQ
 }
 
@@ -82,7 +83,6 @@ static void iCap_dma_finish_irq() {
 // e.g. Adafruit_iCap_parallel.begin() checks the value of the xlck pin and
 // skips this if -1.
 iCap_status Adafruit_iCap_parallel::xclk_start(uint32_t freq) {
-
   // LOOK UP PWM SLICE & CHANNEL BASED ON XCLK PIN -------------------------
 
   uint8_t slice = pwm_gpio_to_slice_num(pins.xclk);
@@ -111,7 +111,6 @@ iCap_status Adafruit_iCap_parallel::xclk_start(uint32_t freq) {
 // Start parallel capture peripheral and DMA. Transfers are not started
 // yet, until frame size and buffer are established.
 iCap_status Adafruit_iCap_parallel::pcc_start(void) {
-
   // TO DO: verify the DATA pins are contiguous.
 
   archptr = arch; // Save arch pointer for interrupts
@@ -192,7 +191,7 @@ iCap_status Adafruit_iCap_parallel::pcc_start(void) {
 // Changing resolution also requires stopping DMA temporarily...
 // wait for frame to finish, do realloc/cam config, then restart.
 // That'll go in Adafruit_iCap_parallel.cpp
-void Adafruit_iCap_parallel::dma_change(uint16_t *dest, uint32_t num_pixels) {
+void Adafruit_iCap_parallel::dma_change(uint16_t* dest, uint32_t num_pixels) {
   dma_channel_set_write_addr(archptr->dma_channel, dest, false);
   dma_channel_set_trans_count(archptr->dma_channel, num_pixels, false);
 }

--- a/src/arch/samd51.cpp
+++ b/src/arch/samd51.cpp
@@ -15,7 +15,7 @@
 // single parallel capture peripheral).
 
 static Adafruit_ZeroDMA dma;
-static DmacDescriptor *descriptor;       ///< DMA descriptor
+static DmacDescriptor* descriptor;       ///< DMA descriptor
 static volatile bool frameReady = false; ///< true at end-of-frame
 static volatile bool suspended = true;   ///< Start in suspended state
 
@@ -49,19 +49,20 @@ static void startFrame(void) {
 }
 
 // End-of-DMA-transfer callback
-static void dmaCallback(Adafruit_ZeroDMA *dma) { frameReady = true; }
+static void dmaCallback(Adafruit_ZeroDMA* dma) {
+  frameReady = true;
+}
 
 // XCLK clock out setup. For self-clocking cameras, don't call this function,
 // e.g. Adafruit_iCap_parallel.begin() checks the value of the xlck pin and
 // skips this if -1.
 iCap_status Adafruit_iCap_parallel::xclk_start(uint32_t freq) {
-
   // LOOK UP TIMER OR TCC BASED ON ADDRESS IN ARCH STRUCT ------------------
 
   static const struct {
-    void *base;       ///< TC or TCC peripheral base address
+    void* base;       ///< TC or TCC peripheral base address
     uint8_t GCLK_ID;  ///< Timer ID for GCLK->PCHCTRL
-    const char *name; ///< Printable timer ID for debug use
+    const char* name; ///< Printable timer ID for debug use
   } timer[] = {
 #if defined(TC0)
     {TC0, TC0_GCLK_ID, "TC0"},
@@ -151,7 +152,7 @@ iCap_status Adafruit_iCap_parallel::xclk_start(uint32_t freq) {
 
   if (is_tcc) { // Is a TCC peripheral
 
-    Tcc *tcc = (Tcc *)timer[timer_list_index].base;
+    Tcc* tcc = (Tcc*)timer[timer_list_index].base;
 
     tcc->CTRLA.bit.ENABLE = 0; // Disable TCC before configuring
     while (tcc->SYNCBUSY.bit.ENABLE)
@@ -176,7 +177,7 @@ iCap_status Adafruit_iCap_parallel::xclk_start(uint32_t freq) {
 
   } else { // Is a TC peripheral
 
-    Tc *tc = (Tc *)timer[timer_list_index].base;
+    Tc* tc = (Tc*)timer[timer_list_index].base;
 
     // TO DO: ADD TC PERIPHERAL (NOT TCC) CODE HERE
 
@@ -189,7 +190,6 @@ iCap_status Adafruit_iCap_parallel::xclk_start(uint32_t freq) {
 
 // Start parallel capture peripheral
 iCap_status Adafruit_iCap_parallel::pcc_start(void) {
-
   PCC->MR.bit.PCEN = 0; // Make sure PCC is disabled before setting MR reg
 
   PCC->IDR.reg = 0b1111;       // Disable all PCC interrupts
@@ -229,12 +229,12 @@ iCap_status Adafruit_iCap_parallel::pcc_start(void) {
   dma.setPriority(DMA_PRIORITY_3);
 
   // Use 32-bit PCC transfers (4 bytes accumulate in RHR.reg)
-  descriptor = dma.addDescriptor((void *)(&PCC->RHR.reg), // Source
-                                 NULL,                    // Dest set later
-                                 0,                       // Count set later
-                                 DMA_BEAT_SIZE_WORD,      // 32-bit words
-                                 false,                   // Don't src++
-                                 true);                   // Do dest++
+  descriptor = dma.addDescriptor((void*)(&PCC->RHR.reg), // Source
+                                 NULL,                   // Dest set later
+                                 0,                      // Count set later
+                                 DMA_BEAT_SIZE_WORD,     // 32-bit words
+                                 false,                  // Don't src++
+                                 true);                  // Do dest++
 
   // A pin FALLING interrupt is used to detect the start of a new frame.
   // Seems like the PCC RXBUFF and/or ENDRX interrupts could take care
@@ -245,8 +245,8 @@ iCap_status Adafruit_iCap_parallel::pcc_start(void) {
   return ICAP_STATUS_OK;
 }
 
-void Adafruit_iCap_parallel::dma_change(uint16_t *dest, uint32_t num_pixels) {
-  dma.changeDescriptor(descriptor, (void *)(&PCC->RHR.reg), (void *)dest,
+void Adafruit_iCap_parallel::dma_change(uint16_t* dest, uint32_t num_pixels) {
+  dma.changeDescriptor(descriptor, (void*)(&PCC->RHR.reg), (void*)dest,
                        num_pixels / 2);
 }
 

--- a/src/arch/samd51.h
+++ b/src/arch/samd51.h
@@ -9,7 +9,7 @@ typedef int8_t iCap_pin;
 // Device-specific structure attached to Adafruit_ImageCapture.arch,
 // if low-level peripherals can't be inferred from pin numbers.
 typedef struct {
-  void *timer;    ///< TC or TCC peripheral base address for XCLK out
+  void* timer;    ///< TC or TCC peripheral base address for XCLK out
   bool xclk_pdec; ///< If true, XCLK needs special PDEC pin mux
 } iCap_arch;
 


### PR DESCRIPTION
This PR adds proper clang-format CI checking:

- **Add .clang-format configuration** - Uses standard Adafruit formatting rules
- **Add separate clang-format job** - Runs before the build job to catch formatting issues early  
- **Format all source files** - Applied clang-format to all .cpp/.h files
- **Build job depends on clang-format** - Ensures formatting passes before building

cc @ladyada